### PR TITLE
スレッド新規作成機能追加、各テーブルの見直し、リレーション追加

### DIFF
--- a/app/Artist.php
+++ b/app/Artist.php
@@ -13,6 +13,11 @@ class Artist extends Model
     const BIRTHDAY_LABEL = "誕生日";
     const JOIN_YEAR_LABEL = "入所日";
 
+    public function threads()
+    {
+        return $this->hasMany('App\Thread');
+    }
+
     public static function fetchProfileByName(string $name)
     {
         return Artist::where('talk_board', $name)->first();

--- a/app/Http/Controllers/ArtistController.php
+++ b/app/Http/Controllers/ArtistController.php
@@ -5,10 +5,17 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Artist;
 use App\Post;
+use App\Thread;
 use Illuminate\Support\Facades\Auth;
 
 class ArtistController extends controller
 {
+    public static function makeThreadList()
+    {
+        $threadList = Thread::all();
+        return $threadList;
+    }
+
     public function index(Request $request)
     {
         $artists = Artist::fetchProfileBySearch($request);
@@ -18,33 +25,124 @@ class ArtistController extends controller
         return view('artist.all', ['artists' => $artists, 'image' => $image, 'searchWordList' => $searchWordList]);
     }
 
+    public function post(Request $request)
+    {
+        $user = Auth::user();
+        $post = Post::postDataSave($request, $user);
+
+        return redirect("snowman/profile/" . $request->threadId);
+    }
+
+    public function postIndex($threadId)
+    {
+        $posts = Post::where('thread_id', $threadId)->orderBy('created_at', 'desc')->get();
+        $threadList = self::makeThreadList();
+        $thread_name = Thread::where('id', $threadId)->value('thread_name'); // $posts->thread->thread_nameとしたかったがpostsが何もないスレッドだとエラーが生じる
+
+        return view('artist.talkboard', ['thread_name' => $thread_name, 'threadId' => $threadId, 'posts' => $posts, 'threadList' => $threadList]);
+    }
+
+    public function addThread(Request $request)
+    {
+        $thread = Thread::addThread($request);
+        $add_id = Thread::max('id');
+
+        return redirect("snowman/profile/" . $add_id);
+    }
+
+    public function myPostIndex()
+    {
+        $id = Auth::user()->id;
+        $myPosts = Post::where('user_id', $id)->orderBy('created_at', 'desc')->get();
+
+        return view('artist.mypage', ['myPosts' => $myPosts]);
+    }
+
+    public function makeCheckBox() //スレッド新規作成画面の誰の話題か選ぶためのチェックボックス作成（とりあえずネットのコピペ）
+    {
+        $threadList = self::makeThreadList();
+
+        $chkDatas = [
+            "chk01" => "佐久間大介",
+            "chk02" => "岩本照",
+            "chk03" => "渡辺翔太",
+            "chk04" => "深澤辰也",
+            "chk05" => "ラウール",
+            "chk06" => "阿部亮平",
+            "chk07" => "向井康二",
+            "chk08" => "宮舘涼太",
+            "chk09" => "目黒蓮",
+        ];
+        $chk01b = false;
+        $chk02b = false;
+        $chk03b = false;
+        $chk04b = false;
+        $chk05b = false;
+        $chk06b = false;
+        $chk07b = false;
+        $chk08b = false;
+        $chk09b = false;
+
+        if ($chk01b) {
+            $chkChecked["chk01"] = "checked";
+        } else {
+            $chkChecked["chk01"] = "";
+        }
+        if ($chk02b) {
+            $chkChecked["chk02"] = "checked";
+        } else {
+            $chkChecked["chk02"] = "";
+        }
+        if ($chk03b) {
+            $chkChecked["chk03"] = "checked";
+        } else {
+            $chkChecked["chk03"] = "";
+        }
+        if ($chk04b) {
+            $chkChecked["chk04"] = "checked";
+        } else {
+            $chkChecked["chk04"] = "";
+        }
+        if ($chk05b) {
+            $chkChecked["chk05"] = "checked";
+        } else {
+            $chkChecked["chk05"] = "";
+        }
+        if ($chk06b) {
+            $chkChecked["chk06"] = "checked";
+        } else {
+            $chkChecked["chk06"] = "";
+        }
+        if ($chk07b) {
+            $chkChecked["chk07"] = "checked";
+        } else {
+            $chkChecked["chk07"] = "";
+        }
+        if ($chk08b) {
+            $chkChecked["chk08"] = "checked";
+        } else {
+            $chkChecked["chk08"] = "";
+        }
+        if ($chk09b) {
+            $chkChecked["chk09"] = "checked";
+        } else {
+            $chkChecked["chk09"] = "";
+        }
+        return view('artist.addThread', [
+            'threadList' => $threadList,
+            'chkDatas' => $chkDatas,
+            'chkChecked' => $chkChecked
+        ]);
+    }
+
     public function snowman()
     {
         return view('artist.snowman');
     }
-
     public function snowmanprofile()
     {
         return view('artist.snowmanprofile');
     }
-
-    public function post(Request $request)
-    {
-        $name = $request->name;
-        $user = Auth::user();
-        $post = Post::postDataSave($request, $user);
-
-        $redirect = "snowman/profile/" . $name;
-        return redirect($redirect);
-    }
-
-    public function postIndex($name)
-    {
-        $posts = Post::where('commented_at', $name)->get();
-        $profile = Artist::fetchProfileByName($name);
-        return view('artist.talkboard', ['posts' => $posts, 'name' => $name, 'profile' => $profile]);
-    }
-
     public function snowmancheckit()
     {
         return view('artist.snowmancheckit');
@@ -58,12 +156,5 @@ class ArtistController extends controller
     public function sixtones()
     {
         return view('artist.sixtones');
-    }
-
-    public function myPostIndex()
-    {
-        $id = Auth::user()->id;
-        $myPosts = Post::where('user_id', $id)->get();
-        return view('artist.mypage', ['myPosts' => $myPosts]);
     }
 }

--- a/app/Post.php
+++ b/app/Post.php
@@ -18,11 +18,14 @@ class Post extends Model
         return $this->belongsTo('App\User');
     }
 
+    public function thread()
+    {
+        return $this->belongsTo('App\Thread');
+    }
+
     public static function postDataSave(Request $request, $user)
     {
-        $name = $request->name;
         $form = $request->all();
-
         $post = new Post;
         if (isset($form['image'])) {
             $path = $request->file('image')->store('public/image');
@@ -31,9 +34,9 @@ class Post extends Model
             $post->image_path = null;
         }
 
+        $form['thread_id'] = $request->threadId;
         $form['name'] = $user->name;
         $form['user_id'] = $user->id;
-        $form['commented_at'] = $name;
 
         unset($form['_token']);
         unset($form['image']);

--- a/app/Thread.php
+++ b/app/Thread.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App;
+
+use App\Artist;
+use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Model;
+
+class Thread extends Model
+{
+
+    protected $fillable = ['thread_name', 'artist_id'];
+
+    public function artist()
+    {
+        return $this->belongsTo('App\Artist');
+    }
+
+    public function post()
+    {
+        return $this->hasMany('App\Post');
+    }
+
+    public static function addThread(Request $request)
+    {
+        $selectedName = $request->talkAbout;
+        $form = $request->all();
+        $thread = new Thread;
+
+        $form['artist_id'] = Artist::where('名前', $selectedName)->value('id');
+        $form['thread_name'] = $request->thread_name;
+
+        unset($form['_token']);
+
+        $thread->fill($form);
+        $thread->save();
+    }
+}

--- a/database/migrations/2021_04_08_034842_create_threads_table.php
+++ b/database/migrations/2021_04_08_034842_create_threads_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateThreadsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('threads', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('thread_name');
+            $table->integer('artist_id');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('threads');
+    }
+}

--- a/database/migrations/2021_04_08_064930_modify_posts_table.php
+++ b/database/migrations/2021_04_08_064930_modify_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('name');
+        });
+    }
+}

--- a/database/migrations/2021_04_08_065947_add_column_thread_id_to_posts_table.php
+++ b/database/migrations/2021_04_08_065947_add_column_thread_id_to_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnThreadIdToPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->integer('thread_id')->after('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('thread_id');
+        });
+    }
+}

--- a/database/migrations/2021_04_08_081105_delete_column_commented_at_from_posts_table.php
+++ b/database/migrations/2021_04_08_081105_delete_column_commented_at_from_posts_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class DeleteColumnCommentedAtFromPostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->dropColumn('commented_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('posts', function (Blueprint $table) {
+            $table->string('commented_at');
+        });
+    }
+}

--- a/resources/views/artist/addThread.blade.php
+++ b/resources/views/artist/addThread.blade.php
@@ -1,0 +1,73 @@
+@extends('layouts.admin')
+@section('title', 'addThread')
+@section('content')
+<div class="container">
+    <div class="row py-4">
+        <div class="col-md-3 order-1" id="sticky-sidebar">
+            <div class="sticky-top">
+                <div class="nav flex-column">
+                    <p>talk about...?</p>
+                    <a href="{{ action('ArtistController@makeCheckBox') }}" role="button" class="btn btn-primary">新規作成</a>
+                    @foreach ($threadList as $thread)
+                    <a href="/snowman/profile/{{ $thread->id }}" class="nav-link" style="color:black">{{ $thread->thread_name }}</a>
+                    @endforeach
+                </div>
+            </div>
+        </div>
+        <div class="col-md-8 order-2" id="main">
+            <!-- <div class="row"> -->
+            <!-- <div class="col-md-12 mx-auto"> -->
+            <div class="border">
+                <h4 class="text-center">新規作成</h4>
+                <br>
+                <form action="{{ action('ArtistController@addThread') }}" method="post">
+                    @if (count($errors) > 0)
+                    <ul>
+                        @foreach($errors->all() as $e)
+                        <li>{{ $e }}</li>
+                        @endforeach
+                    </ul>
+                    @endif
+                    {{ csrf_field() }}
+                    <div class="form-group col-md-12">
+                        <label>スレッド名</label>
+                        <textarea class="form-control" name="thread_name">{{ old('thread_name') }}</textarea>
+                        <br>
+                        <label for="chk01" class="col-form-label">誰についての話題ですか？</label>
+                        <div class="col-md-12">
+                            @foreach($chkDatas as $ckey => $cval)
+                            <div class="form-check form-check-inline">
+                                <input class="form-check-input" type="checkbox" id="chk01" name="talkAbout" value="{{$cval}}" @if(empty(old()) and $chkChecked[$ckey]=='checked' ) checked="checked" @elseif($ckey==old($ckey))) checked="checked" @endif>
+                                <label class="form-check-label" for="{{$ckey}}">{{$cval}}</label>
+                            </div>
+                            @endforeach
+                        </div>
+                        <br>
+                        {{ csrf_field() }}
+                        <input type="submit" class="btn btn-primary" value="作成">
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection
+
+@section('johnnys')
+https://www.johnnys-net.jp/page?id=artistTop&artist=43
+@endsection
+@section('record')
+https://avex.jp/snowman/
+@endsection
+@section('twitter')
+https://twitter.com/sore_snowman
+@endsection
+@section('instagram')
+https://www.instagram.com/j_snowman_weibo/?hl=ja
+@endsection
+@section('weibo')
+https://weibo.com/SnowManofficial?is_all=1
+@endsection
+@section('youtube')
+https://www.youtube.com/channel/UCuFPaemAaMR8R5cHzjy23dQ
+@endsection

--- a/resources/views/artist/all.blade.php
+++ b/resources/views/artist/all.blade.php
@@ -1,47 +1,60 @@
 @extends('layouts.admin')
 @section('title', 'アーティスト一覧')
 @section('content')
-    <div class="container">
-        <div class="row">
-            <div class="col-md-10 mx-auto">
-                <h3>アーティスト一覧</h3>
-                <form action="{{ action('ArtistController@index') }}" method="get">
-                    <div class="form-group row">
-                        <label class="col-md-2">名前</label>
-                        <div class="col-md-2">
-                            <input type="text" class="form-control" name="cond_name" value="{{ $searchWordList["名前"] }}">
-                        </div>
-                        <label class="col-md-2">グループ</label>
-                        <div class="col-md-2">
-                            <input type="text" class="form-control" name="cond_group" value="{{ $searchWordList["グループ"] }}">
-                        </div>
-                        <label class="col-md-2">血液型</label>
-                        <div class="col-md-2">
-                            <input type="text" class="form-control" name="cond_blood" value="{{ $searchWordList["血液型"] }}">
-                        </div>
-                        <label class="col-md-2">誕生日</label>
-                        <div class="col-md-2">
-                            <input type="text" class="form-control" name="cond_birthDay" value="{{ $searchWordList["誕生日"] }}">
-                        </div>
-                        <label class="col-md-2">入所日</label>
-                        <div class="col-md-2">
-                            <input type="text" class="form-control" name="cond_joinYear" value="{{ $searchWordList["入所日"] }}">
-                        </div>
+<div class="container">
+    <div class="row">
+        <div class="col-md-10 mx-auto">
+            <h3>アーティスト一覧</h3>
+            <form action="{{ action('ArtistController@index') }}" method="get">
+                <div class="form-group row">
+                    <label class="col-md-2">名前</label>
+                    <div class="col-md-2">
+                        <input type="text" class="form-control" name="cond_name" value="{{ $searchWordList["名前"] }}">
+                    </div>
+                    <label class="col-md-2">グループ</label>
+                    <div class="col-md-2">
+                        <input type="text" class="form-control" name="cond_group" value="{{ $searchWordList["グループ"] }}">
+                    </div>
+                    <label class="col-md-2">血液型</label>
+                    <div class="col-md-2">
+                        <input type="text" class="form-control" name="cond_blood" value="{{ $searchWordList["血液型"] }}">
+                    </div>
+                    <label class="col-md-2">誕生日</label>
+                    <div class="col-md-2">
+                        <input type="text" class="form-control" name="cond_birthDay" value="{{ $searchWordList["誕生日"] }}">
+                    </div>
+                    <label class="col-md-2">入所日</label>
+                    <div class="col-md-2">
+                        <input type="text" class="form-control" name="cond_joinYear" value="{{ $searchWordList["入所日"] }}">
+                    </div>
 
-                        <div class="col-md-2">
-                            {{ csrf_field() }}
-                            <input type="submit" class="btn btn-primary" value="検索">
-                        </div>
-                        <table class="table table-hover">
-                            <thead class="thead-lignt">
-                                <tr><th></th><th>名前</th><th>グループ</th><th>誕生日</th><th>血液型</th><th>入所日</th></tr>
-                            </thead>
-                                @foreach($artists as $artist)
-                                <tr><td><a href="{{ asset('/snowman/profile/' . $artist->talk_board ) }}"><img src="{{ asset('image/' . $artist->image_path) }}" class="img-thumbnail" alt="参考画像" width="120" height="120"></td>
-                                <td>{{ $artist->名前 }}</td><td>{{ $artist->グループ }}</td><td>{{ $artist->誕生日 }}</td><td>{{ $artist->血液型 }}</td><td>{{ $artist->入所日 }}</a></td></tr>
-                                @endforeach
-                        </table>
-            </div>    
+                    <div class="col-md-2">
+                        {{ csrf_field() }}
+                        <input type="submit" class="btn btn-primary" value="検索">
+                    </div>
+                    <table class="table table-hover">
+                        <thead class="thead-lignt">
+                            <tr>
+                                <th></th>
+                                <th>名前</th>
+                                <th>グループ</th>
+                                <th>誕生日</th>
+                                <th>血液型</th>
+                                <th>入所日</th>
+                            </tr>
+                        </thead>
+                        @foreach($artists as $artist)
+                        <tr>
+                            <td><a href="{{ asset('/snowman/profile/' . $artist->id ) }}"><img src="{{ asset('image/' . $artist->image_path) }}" class="img-thumbnail" alt="参考画像" width="120" height="120"></td>
+                            <td>{{ $artist->名前 }}</td>
+                            <td>{{ $artist->グループ }}</td>
+                            <td>{{ $artist->誕生日 }}</td>
+                            <td>{{ $artist->血液型 }}</td>
+                            <td>{{ $artist->入所日 }}</a></td>
+                        </tr>
+                        @endforeach
+                    </table>
+                </div>
         </div>
     </div>
-@endsection
+    @endsection

--- a/resources/views/artist/mypage.blade.php
+++ b/resources/views/artist/mypage.blade.php
@@ -6,18 +6,18 @@
         <h2>コメント履歴</h2>
         <form action="{{ action('ArtistController@myPostIndex') }}" method="get">
             @if ($myPosts != NULL)
-                @foreach ($myPosts as $myPost)
-                    <div class="card">
-                        <div class="card-body">
-                            {{ $myPost->comment }}<br>
-                            @if ($myPost->image_path)
-                            <img src="{{ asset('storage/image/' . $myPost->image_path) }}" style="width: 100px"><br>
-                            @endif
-                            <a href="{{ asset('/snowman/profile/' . $myPost->commented_at) }}">{{"@" . $myPost->commented_at}}</a><br>
-                            {{ $myPost->created_at }}
-                        </div>  
-                    </div>
-                @endforeach
+            @foreach ($myPosts as $myPost)
+            <div class="card">
+                <div class="card-body">
+                    {{ $myPost->comment }}<br>
+                    @if ($myPost->image_path)
+                    <img src="{{ asset('storage/image/' . $myPost->image_path) }}" style="width: 100px"><br>
+                    @endif
+                    <a href="{{ asset('/snowman/profile/' . $myPost->thread->id) }}">{{"@" . $myPost->thread->thread_name}}</a><br>
+                    {{ $myPost->created_at }}
+                </div>
+            </div>
+            @endforeach
             @endif
         </form>
     </div>

--- a/resources/views/artist/snowmanprofile.blade.php
+++ b/resources/views/artist/snowmanprofile.blade.php
@@ -1,30 +1,30 @@
 @extends('layouts.admin')
 @section('title', 'profile')
 @section('content')
-    <div class="container ">
-        <div class="row">
-            <div class="col-md-9 mx-auto">
-                <h3 class="text-center">talk about ...?</h2>
+<div class="container ">
+    <div class="row">
+        <div class="col-md-9 mx-auto">
+            <h3 class="text-center">talk about ...?</h2>
                 <table class="mx-auto">
                     <tr>
-                    <td><a href="/snowman/profile/abe"><img class="rounded-full" src="{{ asset('image/abe.jpg') }}" alt=""></a></td>
-                    <td><a href="/snowman/profile/miyadate"><img class="rounded-full" src="{{ asset('image/date.jpg') }}" alt=""></a></td>
-                    <td><a href="/snowman/profile/fukazawa"><img class="rounded-full" src="{{ asset('image/hukka.jpg') }}" alt=""></a></td>                        
+                        <td><a href="/snowman/profile/6"><img class="rounded-full" src="{{ asset('image/abe.jpg') }}" alt=""></a></td>
+                        <td><a href="/snowman/profile/8"><img class="rounded-full" src="{{ asset('image/date.jpg') }}" alt=""></a></td>
+                        <td><a href="/snowman/profile/4"><img class="rounded-full" src="{{ asset('image/hukka.jpg') }}" alt=""></a></td>
                     </tr>
                     <tr>
-                    <td><a href="/snowman/profile/meguro"><img class="rounded-full" src="{{ asset('image/meme.jpg') }}" alt=""></a></td>
-                    <td><a href="/snowman/profile/mukai"><img class="rounded-full" src="{{ asset('image/mukai.jpg') }}" alt=""></a></td>
-                    <td><a href="/snowman/profile/raul"><img class="rounded-full" src="{{ asset('image/raul.jpg') }}" alt=""></a></td>                        
+                        <td><a href="/snowman/profile/9"><img class="rounded-full" src="{{ asset('image/meme.jpg') }}" alt=""></a></td>
+                        <td><a href="/snowman/profile/7"><img class="rounded-full" src="{{ asset('image/mukai.jpg') }}" alt=""></a></td>
+                        <td><a href="/snowman/profile/5"><img class="rounded-full" src="{{ asset('image/raul.jpg') }}" alt=""></a></td>
                     </tr>
                     <tr>
-                    <td><a href="/snowman/profile/sakuma"><img class="rounded-full" src="{{ asset('image/sakkun.jpg') }}" alt=""></a></td>
-                    <td><a href="/snowman/profile/watanabe"><img class="rounded-full" src="{{ asset('image/shoppi.jpg') }}" alt=""></a></td>
-                    <td><a href="/snowman/profile/iwamoto"><img class="rounded-full" src="{{ asset('image/iwamoto.jpg') }}" alt=""></a></td>                        
+                        <td><a href="/snowman/profile/1"><img class="rounded-full" src="{{ asset('image/sakkun.jpg') }}" alt=""></a></td>
+                        <td><a href="/snowman/profile/3"><img class="rounded-full" src="{{ asset('image/shoppi.jpg') }}" alt=""></a></td>
+                        <td><a href="/snowman/profile/2"><img class="rounded-full" src="{{ asset('image/iwamoto.jpg') }}" alt=""></a></td>
                     </tr>
                 </table>
-            </div>
         </div>
-    </div>    
+    </div>
+</div>
 
 @endsection
 

--- a/resources/views/artist/talkboard.blade.php
+++ b/resources/views/artist/talkboard.blade.php
@@ -7,43 +7,34 @@
             <div class="sticky-top">
                 <div class="nav flex-column">
                     <p>talk about...?</p>
-                    <a href="/snowman/profile/sakuma" class="nav-link" style="color:black">佐久間大介</a>
-                    <a href="/snowman/profile/abe" class="nav-link" style="color:black">阿部亮平</a>
-                    <a href="/snowman/profile/iwamoto" class="nav-link" style="color:black">岩本照</a>
-                    <a href="/snowman/profile/miyadate" class="nav-link" style="color:black">宮舘涼太</a>
-                    <a href="/snowman/profile/raul" class="nav-link" style="color:black">ラウール</a>
-                    <a href="/snowman/profile/meguro" class="nav-link" style="color:black">目黒蓮</a>
-                    <a href="/snowman/profile/fukazawa" class="nav-link" style="color:black">深澤辰也</a>
-                    <a href="/snowman/profile/mukai" class="nav-link" style="color:black">向井康二</a>
-                    <a href="/snowman/profile/watanabe" class="nav-link" style="color:black">渡辺翔太</a>
+                    <a href="{{ action('ArtistController@makeCheckBox') }}" role="button" class="btn btn-primary">新規作成</a>
+                    @foreach ($threadList as $thread)
+                    <a href="/snowman/profile/{{ $thread->id }}" class="nav-link" style="color:black">#{{ $thread->thread_name }}</a>
+                    @endforeach
                 </div>
             </div>
         </div>
         <div class="col-md-8 order-2" id="main">
-            <!-- <div class="row"> -->
-            <!-- <div class="col-md-12 mx-auto"> -->
             <div class="border">
                 <h4 class="text-center">talk board</h4>
-                <h2 class="text-center">-{{ $profile->名前 }}-</h2>
+                <h2 class="text-center">-{{ $thread_name }}-</h2>
                 <br>
-                <form action="{{ action('ArtistController@post', ['name' => $name]) }}" method="post" enctype="multipart/form-data"></form>
-                @if (count($errors) > 0)
-                <ul>
-                    @foreach($errors->all() as $e)
-                    <li>{{ $e }}</li>
-                    @endforeach
-                </ul>
-                @endif
-                {{ csrf_field() }}
-                <div class="form-group col-md-12">
-                    <label>コメント</label>
-                    <textarea class="form-control" name="comment" rows="5">{{ old('comment')}}</textarea>
-                    <form>
+                <form action="{{ action('ArtistController@post', ['threadId' => $threadId]) }}" method="post" enctype="multipart/form-data">
+                    @if (count($errors) > 0)
+                    <ul>
+                        @foreach($errors->all() as $e)
+                        <li>{{ $e }}</li>
+                        @endforeach
+                    </ul>
+                    @endif
+                    {{ csrf_field() }}
+                    <div class="form-group col-md-12">
+                        <label>コメント</label>
+                        <textarea class="form-control" name="comment" rows="5">{{ old('comment')}}</textarea>
                         <div class="input-group">
                             <div class="input-group-prepend">
                                 <span class="input-group-text" id="inputGroupFileAddon">画像選択</span>
                             </div>
-
                             <div class="custom-file col-5">
                                 <input type="file" class="custom-file-input" id="inputGroupFile" name="image" accept=".png,.jpg,.jpeg,image/png,image/jpg" aria-describedby="inputGroupFileAddon">
                                 <label class="custom-file-label" for="inputGroupFile" data-browse="参照">ファイルを選択</label>
@@ -53,27 +44,28 @@
                             <button class="btn btn-info col-md-2">\\ 推す //</button>
                         </div>
                         <br>
-                </div>
+                </form>
             </div>
-            <form action="{{ action('ArtistController@postIndex', ['name'=>$name]) }}" method="get"></form>
-            @if (count($posts) > 0)
-            @foreach($posts as $post)
-            <table class="table">
-                <tr>
-                    <td>
-                        {{ $post->user->name }}<br>
-                        {{ $post->comment }}<br>
-                        @if ($post->image_path)
-                        <img src="{{ asset('storage/image/' . $post->image_path) }}" style="width: 100px"><br>
-                        @endif
-                        {{ $post->created_at }}
-                    </td>
-                </tr>
-            </table>
-            @endforeach
-            @endif
         </div>
+        <form action="{{ action('ArtistController@postIndex', ['threadId' => $threadId]) }}" method="get"></form>
+        @if (count($posts) > 0)
+        @foreach($posts as $post)
+        <table class="table">
+            <tr>
+                <td>
+                    {{ $post->user->name }}<br>
+                    {{ $post->comment }}<br>
+                    @if ($post->image_path)
+                    <img src="{{ asset('storage/image/' . $post->image_path) }}" style="width: 100px"><br>
+                    @endif
+                    {{ $post->created_at }}
+                </td>
+            </tr>
+        </table>
+        @endforeach
+        @endif
     </div>
+</div>
 </div>
 @endsection
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,21 +15,25 @@
 //     return view('welcome');
 // })->where('any','.*');
 
+use Illuminate\Contracts\Routing\UrlRoutable;
+
 Route::get('/', function () {
     return view('welcome');
 });
 
 
+Route::post('/snowman/profile/{threadId}', 'ArtistController@post')->middleware('auth');
+Route::get('/snowman/profile/{threadId}', 'ArtistController@postIndex')->middleware('auth');
+Route::post('/snowman/add', 'ArtistController@addThread')->name('home');
+Route::get('/snowman/add', 'ArtistController@makeCheckBox')->name('home');
+Route::get('/mypage', 'ArtistController@myPostIndex')->middleware('auth');
 Route::get('/all', 'ArtistController@index')->middleware('auth');
+
 Route::get('/snowman', 'ArtistController@snowman')->middleware('auth');
 Route::get('/sixtones', 'ArtistController@sixtones')->middleware('auth');
 Route::get('/snowman/profile', 'ArtistController@snowmanprofile')->middleware('auth');
-Route::post('/snowman/profile/{name}', 'ArtistController@post')->middleware('auth');
 Route::get('/snowman/checkit', 'ArtistController@snowmancheckit')->middleware('auth');
 Route::get('/snowman/mustgo', 'ArtistController@snowmanmustgo')->middleware('auth');
-Route::get('/snowman/profile/{name}', 'ArtistController@postIndex')->middleware('auth');
-Route::get('/mypage', 'ArtistController@myPostIndex')->middleware('auth');
 Route::get('/home', 'HomeController@index')->name('home');
-
 
 Auth::routes();


### PR DESCRIPTION
スレッド新規作成ページを作ってthreads_tableに保存、保存後は作ったスレッドページにリダイレクト。
サイドバーのスレッド一覧はthread_tableをforeachで表示させるようにしました。
チェックボックスについては調べたサイトのコードそのままコピペなのでまた改めて見直します。
また、現状複数チェックすると後の人の番号しかデータベースに残らないのでその点も検討します。

各テーブルについても同じような値はなくして外部キーを保持するように変更、
それぞれのリレーションを下記のように考えました。

お手すきの際ご確認お願い致します。

[![Image from Gyazo](https://i.gyazo.com/ad6f2a0494bbe53744106f138e2ea1a4.png)](https://gyazo.com/ad6f2a0494bbe53744106f138e2ea1a4)

[![Image from Gyazo](https://i.gyazo.com/e2cebcc99f79046633acebec32c91e7b.png)](https://gyazo.com/e2cebcc99f79046633acebec32c91e7b)